### PR TITLE
Rewrite macros to allow redirection of errors.

### DIFF
--- a/OCDSpec2.xcodeproj/project.pbxproj
+++ b/OCDSpec2.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		14B7B07017BED2B4001552CE /* OCDSExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 94A6BAA415BB30D0003F22B6 /* OCDSExample.m */; };
 		14B7B07117BED2B8001552CE /* OCDSDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 94A6BAA215BB30D0003F22B6 /* OCDSDescription.m */; };
 		14C9441E17FF3F8700578E2C /* OCDSLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 1428639417C7FD8000066B3C /* OCDSLog.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		14DAD2A31827F9DC00025C63 /* SpecExpectation.m in Sources */ = {isa = PBXBuildFile; fileRef = 14DAD2A21827F9DC00025C63 /* SpecExpectation.m */; };
 		942AAEFD15BBB3E60006C241 /* OCDSContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 94A6BAA015BB30D0003F22B6 /* OCDSContext.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		942AAEFE15BBB3E90006C241 /* OCDSDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 94A6BAA215BB30D0003F22B6 /* OCDSDescription.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		942AAEFF15BBB3EB0006C241 /* OCDSExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 94A6BAA415BB30D0003F22B6 /* OCDSExample.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
@@ -102,6 +103,8 @@
 		14B7B06B17BEC316001552CE /* FakeLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FakeLogger.h; sourceTree = "<group>"; };
 		14B7B06C17BEC316001552CE /* FakeLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FakeLogger.m; sourceTree = "<group>"; };
 		14B7B06E17BECB37001552CE /* OCDSLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OCDSLogger.h; sourceTree = "<group>"; };
+		14DAD2A11827F9DC00025C63 /* SpecExpectation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpecExpectation.h; sourceTree = "<group>"; };
+		14DAD2A21827F9DC00025C63 /* SpecExpectation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SpecExpectation.m; sourceTree = "<group>"; };
 		942AAEEC15BBB3760006C241 /* libOCDSpec2Mac.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libOCDSpec2Mac.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		942AAEF515BBB3760006C241 /* OCDSpec2Mac-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "OCDSpec2Mac-Prefix.pch"; path = "OCDSpec2/OCDSpec2Mac-Prefix.pch"; sourceTree = SOURCE_ROOT; };
 		944FBF5015C168C100BF85FC /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
@@ -184,6 +187,7 @@
 		149894E01762D39E0036608B /* OCDSpec2Specs */ = {
 			isa = PBXGroup;
 			children = (
+				14DAD2A01827F9C000025C63 /* SpecExpectation */,
 				14614E791774E592000AF471 /* Fakes */,
 				149894E11762D39E0036608B /* Supporting Files */,
 				149894EC1762D3EA0036608B /* StringExpectationSpec.m */,
@@ -210,6 +214,15 @@
 				149894E81762D39E0036608B /* OCDSpec2Specs-Prefix.pch */,
 			);
 			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		14DAD2A01827F9C000025C63 /* SpecExpectation */ = {
+			isa = PBXGroup;
+			children = (
+				14DAD2A11827F9DC00025C63 /* SpecExpectation.h */,
+				14DAD2A21827F9DC00025C63 /* SpecExpectation.m */,
+			);
+			name = SpecExpectation;
 			sourceTree = "<group>";
 		};
 		944FBF5215C168C100BF85FC /* Other Frameworks */ = {
@@ -452,6 +465,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				149894E71762D39E0036608B /* main.m in Sources */,
+				14DAD2A31827F9DC00025C63 /* SpecExpectation.m in Sources */,
 				149894ED1762D3EA0036608B /* StringExpectationSpec.m in Sources */,
 				149894F21762DF6E0036608B /* FloatExpectationSpec.m in Sources */,
 				14B7B07117BED2B8001552CE /* OCDSDescription.m in Sources */,

--- a/OCDSpec2/OCDSArrayExpectation.h
+++ b/OCDSpec2/OCDSArrayExpectation.h
@@ -12,4 +12,4 @@
 
 @end
 
-#define ExpectArray [[OCDSArrayExpectation expectationInFile:__FILE__ line:__LINE__ failureReporter:self] withArray]
+#define ExpectArray [[OCDSArrayExpectation expectationInFile:__FILE__ line:__LINE__ failureReporter:Reporter] withArray]

--- a/OCDSpec2/OCDSBlockExpectation.h
+++ b/OCDSpec2/OCDSBlockExpectation.h
@@ -12,4 +12,4 @@
 
 @end
 
-#define ExpectBlock [[OCDSBlockExpectation expectationInFile:__FILE__ line:__LINE__ failureReporter:self] withBlock]
+#define ExpectBlock [[OCDSBlockExpectation expectationInFile:__FILE__ line:__LINE__ failureReporter:Reporter] withBlock]

--- a/OCDSpec2/OCDSExpectation.h
+++ b/OCDSpec2/OCDSExpectation.h
@@ -16,3 +16,5 @@
 - (void) reportWarning:(NSString*)message;
 
 @end
+
+#define Reporter self

--- a/OCDSpec2/OCDSFloatExpectation.h
+++ b/OCDSpec2/OCDSFloatExpectation.h
@@ -12,4 +12,4 @@
 
 @end
 
-#define ExpectFloat [[OCDSFloatExpectation expectationInFile:__FILE__ line:__LINE__ failureReporter:self] withFloat]
+#define ExpectFloat [[OCDSFloatExpectation expectationInFile:__FILE__ line:__LINE__ failureReporter:Reporter] withFloat]

--- a/OCDSpec2/OCDSIntExpectation.h
+++ b/OCDSpec2/OCDSIntExpectation.h
@@ -15,8 +15,7 @@
 
 @end
 
-#define ExpectInt [[OCDSIntExpectation expectationInFile:__FILE__ line:__LINE__ failureReporter:self] withInt]
-#define ExpectBool [[OCDSIntExpectation expectationInFile:__FILE__ line:__LINE__ failureReporter:self] withInt]
-#define ExpectTrue(num) [[[OCDSIntExpectation expectationInFile:__FILE__ line:__LINE__ failureReporter:self] withInt](num) toBeTrue];
-#define ExpectFalse(num) [[[OCDSIntExpectation expectationInFile:__FILE__ line:__LINE__ failureReporter:self] withInt](num) toBeFalse];
-
+#define ExpectInt [[OCDSIntExpectation expectationInFile:__FILE__ line:__LINE__ failureReporter:Reporter] withInt]
+#define ExpectBool [[OCDSIntExpectation expectationInFile:__FILE__ line:__LINE__ failureReporter:Reporter] withInt]
+#define ExpectTrue(num) [[[OCDSIntExpectation expectationInFile:__FILE__ line:__LINE__ failureReporter:Reporter] withInt](num) toBeTrue];
+#define ExpectFalse(num) [[[OCDSIntExpectation expectationInFile:__FILE__ line:__LINE__ failureReporter:Reporter] withInt](num) toBeFalse];

--- a/OCDSpec2/OCDSObjectExpectation.h
+++ b/OCDSpec2/OCDSObjectExpectation.h
@@ -20,7 +20,7 @@
 
 @end
 
-#define ExpectObj [[OCDSObjectExpectation expectationInFile:__FILE__ line:__LINE__ failureReporter:self] withObject]
+#define ExpectObj [[OCDSObjectExpectation expectationInFile:__FILE__ line:__LINE__ failureReporter:Reporter] withObject]
 
-#define Pending() return [[OCDSObjectExpectation expectationInFile:__FILE__ line:__LINE__ failureReporter:self] pending]
-#define PendingStr return [[OCDSObjectExpectation expectationInFile:__FILE__ line:__LINE__ failureReporter:self] pendingWithString]
+#define Pending() return [[OCDSObjectExpectation expectationInFile:__FILE__ line:__LINE__ failureReporter:Reporter] pending]
+#define PendingStr return [[OCDSObjectExpectation expectationInFile:__FILE__ line:__LINE__ failureReporter:Reporter] pendingWithString]

--- a/OCDSpec2/OCDSStringExpectation.h
+++ b/OCDSpec2/OCDSStringExpectation.h
@@ -11,4 +11,4 @@
 
 @end
 
-#define ExpectStr [[OCDSStringExpectation expectationInFile:__FILE__ line:__LINE__ failureReporter:self] withString]
+#define ExpectStr [[OCDSStringExpectation expectationInFile:__FILE__ line:__LINE__ failureReporter:Reporter] withString]

--- a/OCDSpec2Specs/ArrayExpectationSpec.m
+++ b/OCDSpec2Specs/ArrayExpectationSpec.m
@@ -1,6 +1,10 @@
 #import <OCDSpec2/OCDSpec2.h>
 
 #import "OCDSFakeFailureReporter.h"
+#import "SpecExpectation.h"
+
+#undef Reporter
+#define Reporter reporter
 
 OCDSpec2Context(ArrayExpectationSpec) {
   
@@ -13,28 +17,17 @@ OCDSpec2Context(ArrayExpectationSpec) {
   Describe(@"-toContain", ^{
     
     It(@"passes when the array contains the element", ^{
-      [[[OCDSArrayExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withArray]
-       (@[@"a"]) toContain: @"a"];
+      [ExpectArray(@[@"a"]) toContain:@"a"];
       
-      [ExpectInt(reporter.numberOfFailures) toBe:0];
+      ExpectErrorCount(0);
     });
     
     It(@"fails when the array does not contain the element", ^{
-      [[[OCDSArrayExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withArray]
-       (@[@"a"]) toContain: @"b"];
+      [ExpectArray(@[@"a"]) toContain:@"b"];
       
-      [ExpectInt(reporter.numberOfFailures) toBe:3];
+      NSArray *msgs = @[@"Want array (", @"    a", @") to contain b"];
       
-      NSString *report;
-      
-      report = [reporter findFailureMessageInFile:@"file1" onLine:2];
-      [ExpectObj(report) toBeEqualTo:@"Want array ("];
-      
-      report = [reporter findFailureMessageInFile:@"file1" onLine:3];
-      [ExpectObj(report) toBeEqualTo:@"    a"];
-      
-      report = [reporter findFailureMessageInFile:@"file1" onLine:4];
-      [ExpectObj(report) toBeEqualTo:@") to contain b"];
+      ExpectLastErrorMessages(msgs);
     });
     
   });
@@ -42,32 +35,17 @@ OCDSpec2Context(ArrayExpectationSpec) {
   Describe(@"-toBeEqualTo", ^{
     
     It(@"passes when two array are equal", ^{
-      [[[OCDSArrayExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withArray]
-       (@[@"a"]) toBeEqualTo: @[@"a"]];
+      [ExpectArray(@[@"a"]) toBeEqualTo:@[@"a"]];
       
-      [ExpectInt(reporter.numberOfFailures) toBe:0];
+      ExpectErrorCount(0);
     });
     
     It(@"fails when two objects are not equal", ^{
-      [[[OCDSObjectExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withObject]
-       (@[@"a"]) toBeEqualTo: @[@"b"]];
-      NSString *report = [reporter findFailureMessageInFile:@"file1"
-                                                     onLine:2];
+      [ExpectArray(@[@"a"]) toBeEqualTo:@[@"b"]];
       
-      report = [reporter findFailureMessageInFile:@"file1" onLine:2];
-      [ExpectObj(report) toBeEqualTo:@"Want ("];
+      NSArray *msgs = @[@"Want (", @"    b", @"), got (", @"    a", @")"];
       
-      report = [reporter findFailureMessageInFile:@"file1" onLine:3];
-      [ExpectObj(report) toBeEqualTo:@"    b"];
-      
-      report = [reporter findFailureMessageInFile:@"file1" onLine:4];
-      [ExpectObj(report) toBeEqualTo:@"), got ("];
-
-      report = [reporter findFailureMessageInFile:@"file1" onLine:5];
-      [ExpectObj(report) toBeEqualTo:@"    a"];
-
-      report = [reporter findFailureMessageInFile:@"file1" onLine:6];
-      [ExpectObj(report) toBeEqualTo:@")"];
+      ExpectLastErrorMessages(msgs);
     });
     
   });
@@ -75,20 +53,15 @@ OCDSpec2Context(ArrayExpectationSpec) {
   Describe(@"-toHaveCount", ^{
     
     It(@"passes if the count is the same", ^{
-      [[[OCDSArrayExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withArray]
-       (@[@"a", @"b", @"c"]) toHaveCount: 3];
+      [ExpectArray(@[@"a", @"b", @"c"]) toHaveCount:3];
       
-      [ExpectInt(reporter.numberOfFailures) toBe:0];
+      ExpectErrorCount(0);
     });
     
     It(@"fails when the count does not match expected", ^{
-      [[[OCDSArrayExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withArray]
-       (@[@"a", @"b", @"c"]) toHaveCount: 2];
-      
-      NSString *report = [reporter findFailureMessageInFile:@"file1"
-                                                     onLine:2];
-      
-      [ExpectObj(report) toBeEqualTo:@"Want count 2, got 3"];
+      [ExpectArray(@[@"a", @"b", @"c"]) toHaveCount:2];
+
+      ExpectLastErrorMessage(@"Want count 2, got 3");
     });
 
   });
@@ -96,27 +69,17 @@ OCDSpec2Context(ArrayExpectationSpec) {
   Describe(@"-toBeEmpty", ^{
     
     It(@"passes when the array is empty", ^{
-      [[[OCDSArrayExpectation expectationInFile:"file1" line:2 failureReporter: reporter] withArray]
-       (@[]) toBeEmpty];
-
-      [ExpectInt(reporter.numberOfFailures) toBe:0];
+      [ExpectArray(@[]) toBeEmpty];
+      
+      ExpectErrorCount(0);
     });
 
     It(@"fails when the array is not empty", ^{
-      [[[OCDSArrayExpectation expectationInFile:"file1" line:2 failureReporter: reporter] withArray]
-       (@[@"a"]) toBeEmpty];
+      [ExpectArray(@[@"a"]) toBeEmpty];
       
-      NSString *report = [reporter findFailureMessageInFile:@"file1"
-                                                     onLine:2];
+      NSArray *msgs = @[@"Want empty array, got (", @"    a", @")"];
       
-      report = [reporter findFailureMessageInFile:@"file1" onLine:2];
-      [ExpectObj(report) toBeEqualTo:@"Want empty array, got ("];
-      
-      report = [reporter findFailureMessageInFile:@"file1" onLine:3];
-      [ExpectObj(report) toBeEqualTo:@"    a"];
-      
-      report = [reporter findFailureMessageInFile:@"file1" onLine:4];
-      [ExpectObj(report) toBeEqualTo:@")"];
+      ExpectLastErrorMessages(msgs);
     });
 
   });

--- a/OCDSpec2Specs/BlockExpectationSpec.m
+++ b/OCDSpec2Specs/BlockExpectationSpec.m
@@ -1,6 +1,10 @@
 #import <OCDSpec2/OCDSpec2.h>
 
 #import "OCDSFakeFailureReporter.h"
+#import "SpecExpectation.h"
+
+#undef Reporter
+#define Reporter reporter
 
 OCDSpec2Context(BlockExpectationSpec) {
   
@@ -13,19 +17,15 @@ OCDSpec2Context(BlockExpectationSpec) {
   Describe(@"-toNotRaiseException", ^{
     
     It(@"passes when the block does not raise an exception", ^{
-      [[[OCDSBlockExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withBlock]
-       (^{}) toNotRaiseException];
-    
-      [ExpectInt(reporter.numberOfFailures) toBe:0];
+      [ExpectBlock(^{}) toNotRaiseException];
+      
+      ExpectErrorCount(0);
     });
     
     It(@"fails when the block raises an exception", ^{
-      [[[OCDSBlockExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withBlock]
-       (^{ [NSException raise:NSInternalInconsistencyException format:@"aww"];}) toNotRaiseException];
-      NSString *report = [reporter findFailureMessageInFile:@"file1"
-                                                     onLine:2];
+      [ExpectBlock(^{ [NSException raise:NSInternalInconsistencyException format:@"aww"];}) toNotRaiseException];
       
-      [ExpectObj(report) toBeEqualTo:@"Want no exception, but got one anyway: NSInternalInconsistencyException: aww"];
+      ExpectLastErrorMessage(@"Want no exception, but got one anyway: NSInternalInconsistencyException: aww");
     });
     
   });

--- a/OCDSpec2Specs/FloatExpectationSpec.m
+++ b/OCDSpec2Specs/FloatExpectationSpec.m
@@ -1,6 +1,10 @@
 #import <OCDSpec2/OCDSpec2.h>
 
 #import "OCDSFakeFailureReporter.h"
+#import "SpecExpectation.h"
+
+#undef Reporter
+#define Reporter reporter
 
 OCDSpec2Context(FloatExpectationSpec) {
   
@@ -13,35 +17,27 @@ OCDSpec2Context(FloatExpectationSpec) {
   Describe(@"-toBeWithPrecision", ^{
     
     It(@"passes when two floats are equal", ^{
-      [[[OCDSFloatExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withFloat]
-       (1.0) toBe: 1.0 withPrecision: 0.0000001];
+      [ExpectFloat(1.0) toBe:1.0 withPrecision:0.0000001];
       
-      [ExpectInt(reporter.numberOfFailures) toBe:0];
+      ExpectErrorCount(0);
     });
     
     It(@"passes when two floats are not equal but close enough", ^{
-      [[[OCDSFloatExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withFloat]
-       (1.99999) toBe: 2.0 withPrecision: 0.0001];
+      [ExpectFloat(1.99999) toBe:2.0 withPrecision:0.0001];
       
-      [ExpectInt(reporter.numberOfFailures) toBe:0];
+      ExpectErrorCount(0);
     });
     
     It(@"fails when two floats are not equal", ^{
-      [[[OCDSFloatExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withFloat]
-       (1.2) toBe: 2.1234 withPrecision: 0.0000001];
-      NSString *report = [reporter findFailureMessageInFile:@"file1"
-                                                     onLine:2];
+      [ExpectFloat(1.2) toBe:2.1234 withPrecision:0.000001];
       
-      [ExpectObj(report) toBeEqualTo:@"Want 2.1234, got 1.2"];      
+      ExpectLastErrorMessage(@"Want 2.1234, got 1.2");
     });
     
     It(@"fails when two floats are not equal with very high precision", ^{
-      [[[OCDSFloatExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withFloat]
-       (1.99999) toBe: 2.0 withPrecision: 0.0000001];
-      NSString *report = [reporter findFailureMessageInFile:@"file1"
-                                                     onLine:2];
+      [ExpectFloat(1.99999) toBe:2.0 withPrecision:0.000001];
       
-      [ExpectObj(report) toBeEqualTo:@"Want 2, got 1.99999"];
+      ExpectLastErrorMessage(@"Want 2, got 1.99999");
     });
     
   });

--- a/OCDSpec2Specs/IntExpectationSpec.m
+++ b/OCDSpec2Specs/IntExpectationSpec.m
@@ -1,6 +1,11 @@
 #import <OCDSpec2/OCDSpec2.h>
 
 #import "OCDSFakeFailureReporter.h"
+#import "OCDSIntExpectation.h"
+#import "SpecExpectation.h"
+
+#undef Reporter
+#define Reporter reporter
 
 OCDSpec2Context(IntExpectationSpec) {
 
@@ -13,28 +18,21 @@ OCDSpec2Context(IntExpectationSpec) {
   Describe(@"-toBe", ^{
     
     It(@"passes when two ints are equal", ^{
-      [[[OCDSIntExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withInt]
-       (1) toBe: 1];
+      [ExpectInt(1) toBe:1];
       
-      [ExpectInt(reporter.numberOfFailures) toBe:0];
+      ExpectErrorCount(0);
     });
     
     It(@"fails when two ints are not equal", ^{
-      [[[OCDSIntExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withInt]
-       (2) toBe: 3];
-      NSString *report = [reporter findFailureMessageInFile:@"file1"
-                                                     onLine:2];
+      [ExpectInt(2) toBe:3];
       
-      [ExpectObj(report) toBeEqualTo:@"Want 3, got 2"];
+      ExpectLastErrorMessage(@"Want 3, got 2");
     });
     
     It(@"fails when two ints are equal but one is negative", ^{
-      [[[OCDSIntExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withInt]
-       (-1) toBe: 1];
-      NSString *report = [reporter findFailureMessageInFile:@"file1"
-                                                     onLine:2];
-      
-      [ExpectObj(report) toBeEqualTo:@"Want 1, got -1"];
+      [ExpectInt(-1) toBe:1];
+
+      ExpectLastErrorMessage(@"Want 1, got -1");
     });
     
   });
@@ -42,19 +40,15 @@ OCDSpec2Context(IntExpectationSpec) {
   Describe(@"-toBeTrue", ^{
     
     It(@"passes when the value is true", ^{
-      [[[OCDSIntExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withInt]
-       (YES) toBeTrue];
-      
-      [ExpectInt(reporter.numberOfFailures) toBe:0];
+      [ExpectInt(YES) toBeTrue];
+
+      ExpectErrorCount(0);
     });
     
     It(@"fails when the value is false", ^{
-      [[[OCDSIntExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withInt]
-       (NO) toBeTrue];
-      NSString *report = [reporter findFailureMessageInFile:@"file1"
-                                                     onLine:2];
-      
-      [ExpectObj(report) toBeEqualTo:@"Want true, got false"];
+      [ExpectInt(NO) toBeTrue];
+
+      ExpectLastErrorMessage(@"Want true, got false");
     });
     
   });
@@ -62,19 +56,15 @@ OCDSpec2Context(IntExpectationSpec) {
   Describe(@"-toBeFalse", ^{
     
     It(@"passes when the value is false", ^{
-      [[[OCDSIntExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withInt]
-       (NO) toBeFalse];
-      
-      [ExpectInt(reporter.numberOfFailures) toBe:0];
+      [ExpectInt(NO) toBeFalse];
+
+      ExpectErrorCount(0);
     });
     
     It(@"fails when the value is true", ^{
-      [[[OCDSIntExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withInt]
-       (YES) toBeFalse];
-      NSString *report = [reporter findFailureMessageInFile:@"file1"
-                                                     onLine:2];
-      
-      [ExpectObj(report) toBeEqualTo:@"Want false, got true"];
+      [ExpectInt(YES) toBeFalse];
+
+      ExpectLastErrorMessage(@"Want false, got true");
     });
     
   });
@@ -82,33 +72,27 @@ OCDSpec2Context(IntExpectationSpec) {
   Describe(@"-toBeNotFalse", ^{
     
     It(@"passes when the value is true", ^{
-      [[[OCDSIntExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withInt]
-       (YES) toNotBeFalse];
-      
-      [ExpectInt(reporter.numberOfFailures) toBe:0];
+      [ExpectInt(YES) toNotBeFalse];
+
+      ExpectErrorCount(0);
     });
     
     It(@"passes when the value is a positive int", ^{
-      [[[OCDSIntExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withInt]
-       (3) toNotBeFalse];
+      [ExpectInt(3) toNotBeFalse];
       
-      [ExpectInt(reporter.numberOfFailures) toBe:0];
+      ExpectErrorCount(0);
     });
     
     It(@"passes when the value is a negative int", ^{
-      [[[OCDSIntExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withInt]
-       (-3) toNotBeFalse];
+      [ExpectInt(-3) toNotBeFalse];
       
-      [ExpectInt(reporter.numberOfFailures) toBe:0];
+      ExpectErrorCount(0);
     });
     
     It(@"fails when the value is false", ^{
-      [[[OCDSIntExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withInt]
-       (NO) toNotBeFalse];
-      NSString *report = [reporter findFailureMessageInFile:@"file1"
-                                                   onLine:2];
-    
-      [ExpectObj(report) toBeEqualTo:@"Want anything but false, got false"];
+      [ExpectInt(NO) toNotBeFalse];
+
+      ExpectLastErrorMessage(@"Want anything but false, got false");
     });
       
   });
@@ -117,6 +101,14 @@ OCDSpec2Context(IntExpectationSpec) {
     
     It(@"passes on YES", ^{
       ExpectTrue(YES);
+      
+      ExpectErrorCount(0);
+    });
+    
+    It(@"fails on NO", ^{
+      ExpectTrue(NO);
+      
+      ExpectLastErrorMessage(@"Want true, got false");
     });
 
   });
@@ -125,6 +117,8 @@ OCDSpec2Context(IntExpectationSpec) {
     
     It(@"passes on NO", ^{
       ExpectFalse(NO);
+      
+      ExpectErrorCount(0);
     });
     
   });

--- a/OCDSpec2Specs/OCDSFakeFailureReporter.h
+++ b/OCDSpec2Specs/OCDSFakeFailureReporter.h
@@ -9,7 +9,8 @@
 @property (assign) NSArray* warningReports;
 
 - (int) numberOfFailures;
-- (NSString *) findFailureMessageInFile:(NSString *)file onLine:(int)line;
-- (NSString *) findWarningMessageInFile:(NSString *)file onLine:(int)line;
+- (NSString *) findLastFailureMessageInFile:(NSString *)file;
+- (NSArray *) findLastFailureMessagesInFile:(NSString *)file count:(int)count;
+- (NSString *) findLastWarningMessageInFile:(NSString *)file;
 
 @end

--- a/OCDSpec2Specs/OCDSFakeFailureReporter.m
+++ b/OCDSpec2Specs/OCDSFakeFailureReporter.m
@@ -30,9 +30,9 @@
   return [self.failureReports count];
 }
 
-- (NSString *)findFailureMessageInFile:(NSString *)file onLine:(int)line {
-  for (OCDSFakeFailure *failure in self.failureReports) {
-    if ([failure.inFile isEqualToString:file] && failure.atLine == line) {
+- (NSString *)findLastFailureMessageInFile:(NSString *)file {
+  for (OCDSFakeFailure *failure in [self.failureReports reverseObjectEnumerator]) {
+    if ([failure.inFile isEqualToString:file]) {
       return failure.report;
     }
   }
@@ -40,10 +40,22 @@
   return @"";
 }
 
-- (NSString *)findWarningMessageInFile:(NSString *)file onLine:(int)line {
-  for (OCDSFakeFailure *failure in self.warningReports) {
-    if ([failure.inFile isEqualToString:file] && failure.atLine == line) {
-      return failure.report;
+- (NSArray *)findLastFailureMessagesInFile:(NSString *)file count:(int)count {
+  NSMutableArray *failureMessages = [NSMutableArray new];
+  
+  for (OCDSFakeFailure *failure in [self.failureReports reverseObjectEnumerator]) {
+    if ([failure.inFile isEqualToString:file] && [failureMessages count] < count) {
+      [failureMessages addObject:failure.report];
+    }
+  }
+  
+  return [[failureMessages reverseObjectEnumerator] allObjects];
+}
+
+- (NSString *)findLastWarningMessageInFile:(NSString *)file {
+  for (OCDSFakeFailure *warning in [self.warningReports reverseObjectEnumerator]) {
+    if ([warning.inFile isEqualToString:file]) {
+      return warning.report;
     }
   }
   

--- a/OCDSpec2Specs/ObjectExpectationSpec.m
+++ b/OCDSpec2Specs/ObjectExpectationSpec.m
@@ -1,6 +1,10 @@
 #import <OCDSpec2/OCDSpec2.h>
 
 #import "OCDSFakeFailureReporter.h"
+#import "SpecExpectation.h"
+
+#undef Reporter
+#define Reporter reporter
 
 OCDSpec2Context(ObjectExpectationSpec) {
   
@@ -13,19 +17,15 @@ OCDSpec2Context(ObjectExpectationSpec) {
   Describe(@"-toBeEqualTo", ^{
     
     It(@"passes when two objects are equal", ^{
-      [[[OCDSObjectExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withObject]
-       (@"a") toBeEqualTo: @"a"];
+      [ExpectObj(@"a") toBeEqualTo:@"a"];
       
-      [ExpectInt(reporter.numberOfFailures) toBe:0];
+      ExpectErrorCount(0);
     });
     
     It(@"fails when two objects are not equal", ^{
-      [[[OCDSObjectExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withObject]
-       (@"a") toBeEqualTo: @"b"];
-      NSString *report = [reporter findFailureMessageInFile:@"file1"
-                                                     onLine:2];
+      [ExpectObj(@"a") toBeEqualTo:@"b"];
       
-      [ExpectObj(report) toBeEqualTo:@"Want b, got a"];
+      ExpectLastErrorMessage(@"Want b, got a");
     });
     
   });
@@ -35,21 +35,18 @@ OCDSpec2Context(ObjectExpectationSpec) {
     It(@"passes when two objects are the same object", ^{
       id a = [NSObject new];
       
-      [[[OCDSObjectExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withObject]
-       (a) toBe: a];
+      [ExpectObj(a) toBe:a];
       
-      [ExpectInt(reporter.numberOfFailures) toBe:0];
+      ExpectErrorCount(0);
     });
     
     It(@"fails when two objects are not the same object", ^{
       id a = [NSMutableString stringWithString:@"a"];
       id b = [NSMutableString stringWithString:@"b"];
-      [[[OCDSObjectExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withObject]
-       (a) toBe: b];
-      NSString *report = [reporter findFailureMessageInFile:@"file1"
-                                                     onLine:2];
       
-      [ExpectObj(report) toBeEqualTo:@"Want b, got a"];
+      [ExpectObj(a) toBe:b];
+      
+      ExpectLastErrorMessage(@"Want b, got a");
     });
     
   });
@@ -57,19 +54,15 @@ OCDSpec2Context(ObjectExpectationSpec) {
   Describe(@"-toExist", ^{
     
     It(@"passes when object is not nil", ^{
-      [[[OCDSObjectExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withObject]
-       (@"a") toExist];
+      [ExpectObj(@"a") toExist];
       
-      [ExpectInt(reporter.numberOfFailures) toBe:0];
+      ExpectErrorCount(0);
     });
     
     It(@"fails when object is nil", ^{
-      [[[OCDSObjectExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withObject]
-       (nil) toExist];
-      NSString *report = [reporter findFailureMessageInFile:@"file1"
-                                                     onLine:2];
+      [ExpectObj(nil) toExist];
       
-      [ExpectObj(report) toBeEqualTo:@"Want real object, got nil"];
+      ExpectLastErrorMessage(@"Want real object, got nil");
     });
     
   });
@@ -77,19 +70,15 @@ OCDSpec2Context(ObjectExpectationSpec) {
   Describe(@"-toBeNil", ^{
     
     It(@"passes when object is nil", ^{
-      [[[OCDSObjectExpectation expectationInFile:"file11" line:2 failureReporter:reporter] withObject]
-       (nil) toBeNil];
+      [ExpectObj(nil) toBeNil];
       
-      [ExpectInt(reporter.numberOfFailures) toBe:0];
+      ExpectErrorCount(0);
     });
     
     It(@"fails when object is not nil", ^{
-      [[[OCDSObjectExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withObject]
-       (@"a") toBeNil];
-      NSString *report = [reporter findFailureMessageInFile:@"file1"
-                                                     onLine:2];
+      [ExpectObj(@"a") toBeNil];
       
-      [ExpectObj(report) toBeEqualTo:@"Want nil, got a"];
+      ExpectLastErrorMessage(@"Want nil, got a");
     });
     
   });
@@ -97,28 +86,21 @@ OCDSpec2Context(ObjectExpectationSpec) {
   Describe(@"-toBeMemberOfClass", ^{
     
     It(@"passes when object is a member of the class", ^{
-      [[[OCDSObjectExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withObject]
-       ([NSNull null]) toBeMemberOfClass: [NSNull self]];
-
-      [ExpectInt(reporter.numberOfFailures) toBe:0];
+      [ExpectObj([NSNull null]) toBeMemberOfClass:[NSNull self]];
+      
+      ExpectErrorCount(0);
     });
     
     It(@"fails when object is not a member of the class", ^{
-      [[[OCDSObjectExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withObject]
-       (@2) toBeMemberOfClass: [NSString self]];
-      NSString *report = [reporter findFailureMessageInFile:@"file1"
-                                                     onLine:2];
+      [ExpectObj(@2) toBeMemberOfClass:[NSString self]];
       
-      [ExpectObj(report) toBeEqualTo:@"Want NSString, got __NSCFNumber"];
+      ExpectLastErrorMessage(@"Want NSString, got __NSCFNumber");
     });
     
     It(@"fails when object is a member of a subclass of desired class", ^{
-      [[[OCDSObjectExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withObject]
-       (@"hi") toBeMemberOfClass: [NSString self]];
-      NSString *report = [reporter findFailureMessageInFile:@"file1"
-                                                     onLine:2];
+      [ExpectObj(@"hi") toBeMemberOfClass:[NSString self]];
       
-      [ExpectObj(report) toBeEqualTo:@"Want NSString, got __NSCFConstantString"];
+      ExpectLastErrorMessage(@"Want NSString, got __NSCFConstantString");
     });
     
   });
@@ -126,33 +108,27 @@ OCDSpec2Context(ObjectExpectationSpec) {
   Describe(@"-toBeKindOfClass", ^{
     
     It(@"passes when object's class is desired class", ^{
-      [[[OCDSObjectExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withObject]
-       ([NSNull null]) toBeKindOfClass: [NSNull self]];
+      [ExpectObj([NSNull null]) toBeKindOfClass:[NSNull self]];
       
-      [ExpectInt(reporter.numberOfFailures) toBe:0];
+      ExpectErrorCount(0);
     });
     
     It(@"passes when object's class is obvious subclass of desired class", ^{
-      [[[OCDSObjectExpectation expectationInFile:"file12" line:23 failureReporter:reporter] withObject]
-       ([NSMutableString stringWithString:@"hello"]) toBeKindOfClass: [NSString self]];
+      [ExpectObj([NSMutableString stringWithString:@"hello"]) toBeKindOfClass:[NSString self]];
       
-      [ExpectInt(reporter.numberOfFailures) toBe:0];
+      ExpectErrorCount(0);
     });
     
     It(@"passes when object's class is less obvious subclass of desired class", ^{
-      [[[OCDSObjectExpectation expectationInFile:"file11" line:22 failureReporter:reporter] withObject]
-       (@"hi") toBeKindOfClass: [NSString self]];
+      [ExpectObj(@"hi") toBeKindOfClass:[NSString self]];
       
-      [ExpectInt(reporter.numberOfFailures) toBe:0];
+      ExpectErrorCount(0);
     });
     
     It(@"fails when object's class does not match desired class", ^{
-      [[[OCDSObjectExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withObject]
-       (@2) toBeKindOfClass: [NSString self]];
-      NSString *report = [reporter findFailureMessageInFile:@"file1"
-                                                     onLine:2];
+      [ExpectObj(@2) toBeKindOfClass:[NSString self]];
       
-      [ExpectObj(report) toBeEqualTo:@"Want NSString, got __NSCFNumber"];
+      ExpectLastErrorMessage(@"Want NSString, got __NSCFNumber");
     });
     
   });
@@ -160,31 +136,27 @@ OCDSpec2Context(ObjectExpectationSpec) {
   Describe(@"-pending", ^{
     
     It(@"warns that the test is pending", ^{
-      [[OCDSObjectExpectation expectationInFile:"file1" line:2 failureReporter:reporter] pending];
-      NSString *report = [reporter findWarningMessageInFile:@"file1"
-                                                     onLine:2];
+      Pending();
       
-      [ExpectObj(report) toBeEqualTo:@"Pending"];
+      ExpectLastWarningMessage(@"Pending");
     });
     
     It(@"warns that the test is pending with a string", ^{
-      [[OCDSObjectExpectation expectationInFile:"file1" line:2 failureReporter:reporter] pendingWithString](@"todo = test me");
-      NSString *report = [reporter findWarningMessageInFile:@"file1"
-                                                     onLine:2];
+      PendingStr(@"todo = test me");
       
-      [ExpectObj(report) toBeEqualTo:@"Pending: todo = test me"];
+      ExpectLastWarningMessage(@"Pending: todo = test me");
     });
     
     It(@"stops executing when it encounters pending", ^{
       Pending();
-      
-      [ExpectBool(YES) toBeFalse];
+
+      [NSException raise:@"Error" format:@""];
     });
     
     It(@"stops executing when it encounters pending with a string", ^{
       PendingStr(@"Pending");
       
-      [ExpectBool(YES) toBeFalse];
+      [NSException raise:@"Error" format:@""];
     });
     
   });

--- a/OCDSpec2Specs/SpecExpectation.h
+++ b/OCDSpec2Specs/SpecExpectation.h
@@ -1,0 +1,13 @@
+#import <Foundation/Foundation.h>
+
+#import "OCDSIntExpectation.h"
+#import "OCDSStringExpectation.h"
+
+@interface SpecExpectation : NSObject
+
+@end
+
+#define ExpectErrorCount(num) [[[OCDSIntExpectation expectationInFile:__FILE__ line:__LINE__ failureReporter:self] withInt](num) toBe:Reporter.numberOfFailures]
+#define ExpectLastWarningMessage(msg) [[[OCDSStringExpectation expectationInFile:__FILE__ line:__LINE__ failureReporter:self] withString](msg) toBeEqualTo:[Reporter findLastWarningMessageInFile:@(__FILE__)]]
+#define ExpectLastErrorMessage(msg) [[[OCDSStringExpectation expectationInFile:__FILE__ line:__LINE__ failureReporter:self] withString](msg) toBeEqualTo:[Reporter findLastFailureMessageInFile:@(__FILE__)]]
+#define ExpectLastErrorMessages(msgs) [[[OCDSArrayExpectation expectationInFile:__FILE__ line:__LINE__ failureReporter:self] withArray](msgs) toBeEqualTo:[Reporter findLastFailureMessagesInFile:@(__FILE__) count:[msgs count]]]

--- a/OCDSpec2Specs/SpecExpectation.m
+++ b/OCDSpec2Specs/SpecExpectation.m
@@ -1,0 +1,5 @@
+#import "SpecExpectation.h"
+
+@implementation SpecExpectation
+
+@end

--- a/OCDSpec2Specs/StringExpectationSpec.m
+++ b/OCDSpec2Specs/StringExpectationSpec.m
@@ -1,6 +1,10 @@
 #import <OCDSpec2/OCDSpec2.h>
 
 #import "OCDSFakeFailureReporter.h"
+#import "SpecExpectation.h"
+
+#undef Reporter
+#define Reporter reporter
 
 OCDSpec2Context(StringExpectationSpec) {
 
@@ -13,19 +17,15 @@ OCDSpec2Context(StringExpectationSpec) {
   Describe(@"-toContain", ^{
 
     It(@"passes when hello contains hell", ^{
-      [[[OCDSStringExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withString]
-       (@"hello") toContain: @"hell"];
+      [ExpectStr(@"hello") toContain:@"hell"];
 
-      [ExpectInt(reporter.numberOfFailures) toBe:0];
+      ExpectErrorCount(0);
     });
 
     It(@"fails when hello does not contain jello", ^{
-      [[[OCDSStringExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withString]
-       (@"hello") toContain: @"jello"];
-      NSString *report = [reporter findFailureMessageInFile:@"file1"
-                                                     onLine:2];
+      [ExpectStr(@"hello") toContain:@"jello"];
 
-      [ExpectObj(report) toBeEqualTo:@"Want \"*jello*\", got \"hello\""];
+      ExpectLastErrorMessage(@"Want \"*jello*\", got \"hello\"");
     });
 
   });
@@ -33,19 +33,15 @@ OCDSpec2Context(StringExpectationSpec) {
   Describe(@"-toStartWith", ^{
 
     It(@"passes when hello starts with hell", ^{
-      [[[OCDSStringExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withString]
-       (@"hello") toStartWith: @"hell"];
-
-      [ExpectInt(reporter.numberOfFailures) toBe:0];
+      [ExpectStr(@"hello") toStartWith:@"hell"];
+      
+      ExpectErrorCount(0);
     });
 
     It(@"fails when hello does not start with ell", ^{
-      [[[OCDSStringExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withString]
-       (@"hello") toStartWith: @"ell"];
-      NSString *report = [reporter findFailureMessageInFile:@"file1"
-                                                     onLine:2];
+      [ExpectStr(@"hello") toStartWith:@"ell"];
 
-      [ExpectObj(report) toBeEqualTo:@"Want \"ell*\", got \"hello\""];
+      ExpectLastErrorMessage(@"Want \"ell*\", got \"hello\"");
     });
 
   });
@@ -53,19 +49,15 @@ OCDSpec2Context(StringExpectationSpec) {
   Describe(@"-toBeEqualTo", ^{
 
     It(@"passes when the strings are equal", ^{
-      [[[OCDSStringExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withString]
-       (@"a") toBeEqualTo: @"a"];
-
-      [ExpectInt(reporter.numberOfFailures) toBe:0];
+      [ExpectStr(@"a") toContain:@"a"];
+      
+      ExpectErrorCount(0);
     });
 
     It(@"fails when the two strings are not equal", ^{
-      [[[OCDSStringExpectation expectationInFile:"file1" line:2 failureReporter:reporter] withString]
-       (@"a") toBeEqualTo: @"b"];
-      NSString *report = [reporter findFailureMessageInFile:@"file1"
-                                                     onLine:2];
+      [ExpectStr(@"a") toBeEqualTo:@"b"];
 
-      [ExpectObj(report) toBeEqualTo:@"Want b, got a"];
+      ExpectLastErrorMessage(@"Want b, got a");
     });
 
   });


### PR DESCRIPTION
This allows a fake reporter to be injected and log all the errors.
Doing this mean we can test our macros.
